### PR TITLE
build_linux.sh: remove no_openssl

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -26,7 +26,7 @@ for d in $PLUGINS; do
 		plugin="$(basename "$d")"
 		if [ $plugin != "windows" ]; then
 			echo "  $plugin"
-			$GO build -tags no_openssl -o "${PWD}/bin/$plugin" "$@" "$REPO_PATH"/$d
+			$GO build -o "${PWD}/bin/$plugin" "$@" "$REPO_PATH"/$d
 		fi
 	fi
 done


### PR DESCRIPTION
per https://jira.coreos.com/browse/ART-666 (for FIPS enablement)