### PR TITLE
Bug 1752008: Adds ENV CGO_ENABLED=0 to disable building with cgo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM openshift/origin-release:golang-1.10 as builder
 ADD . /usr/src/plugins
 
 WORKDIR /usr/src/plugins
+ENV CGO_ENABLED=0
 RUN ./build_linux.sh && \
     cd /usr/src/plugins/bin
 


### PR DESCRIPTION
According to @squeed :

> We're seeing occasional situations where our binaries coredump repeatedly - this is tracked in 1725832.

This exports `CGO_ENABLED=0` before we run the build script.
