### PR TITLE
Bug 1754638: loopback: don't tear down

### DIFF
--- a/plugins/main/loopback/loopback.go
+++ b/plugins/main/loopback/loopback.go
@@ -49,27 +49,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 }
 
 func cmdDel(args *skel.CmdArgs) error {
-	if args.Netns == "" {
-		return nil
-	}
-	args.IfName = "lo" // ignore config, this only works for loopback
-	err := ns.WithNetNSPath(args.Netns, func(ns.NetNS) error {
-		link, err := netlink.LinkByName(args.IfName)
-		if err != nil {
-			return err // not tested
-		}
-
-		err = netlink.LinkSetDown(link)
-		if err != nil {
-			return err // not tested
-		}
-
-		return nil
-	})
-	if err != nil {
-		return err // not tested
-	}
-
 	return nil
 }
 

--- a/plugins/main/loopback/loopback_test.go
+++ b/plugins/main/loopback/loopback_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Loopback", func() {
 		It("sets the lo device to DOWN", func() {
 
 			Skip("TODO: add network name")
+			Skip("We don't want to tear loopback down")
 			command.Env = append(environ, fmt.Sprintf("CNI_COMMAND=%s", "DEL"))
 
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)


### PR DESCRIPTION
There is a bug in CRIO that issues deletes against processes running in the root network namespace. This means we take the node's loopback interface down. This is bad.

This bug was always present, BTW, but we skipped loopback on teardown.

/cc @dcbw