### PR TITLE
[DO NOT MERGE] Bug 1725832: 4.2 backport build loopback with no_openssl tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM openshift/origin-release:golang-1.10 as builder
 ADD . /usr/src/plugins
 
 WORKDIR /usr/src/plugins
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
 RUN ./build_linux.sh && \
     cd /usr/src/plugins/bin
 

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -26,7 +26,11 @@ for d in $PLUGINS; do
 		plugin="$(basename "$d")"
 		if [ $plugin != "windows" ]; then
 			echo "  $plugin"
-			$GO build -o "${PWD}/bin/$plugin" "$@" "$REPO_PATH"/$d
+                        if [ $plugin == "loopback" ]; then
+                           $GO build -tags no_openssl -o "${PWD}/bin/$plugin" "$@" "$REPO_PATH"/$d
+                        else
+                           $GO build -o "${PWD}/bin/$plugin" "$@" "$REPO_PATH"/$d
+                        fi
 		fi
 	fi
 done


### PR DESCRIPTION
- build loopback with no_openssl tag for FIPS compliance
- build with CGO_ENABLED=1 to avoid static linking in glibc

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

(backport https://github.com/openshift/containernetworking-plugins/pull/18 to release-4.3)
@dougbtv PTAL