### PR TITLE
[wip] Revert "build_linux.sh: remove no_openssl"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM openshift/origin-release:golang-1.10 as builder
 ADD . /usr/src/plugins
 
 WORKDIR /usr/src/plugins
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
 RUN ./build_linux.sh && \
     cd /usr/src/plugins/bin
 

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -26,7 +26,7 @@ for d in $PLUGINS; do
 		plugin="$(basename "$d")"
 		if [ $plugin != "windows" ]; then
 			echo "  $plugin"
-			$GO build -o "${PWD}/bin/$plugin" "$@" "$REPO_PATH"/$d
+			$GO build -tags no_openssl -o "${PWD}/bin/$plugin" "$@" "$REPO_PATH"/$d
 		fi
 	fi
 done


### PR DESCRIPTION
This reverts commit 37442dc73084b80a1bac806b7849298baee4ff64.
Dynamically link glibc and build with no_openssl for all plugins.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>
