### PR TITLE
[wip] Build all plugins with no_openssl buldtag

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -26,7 +26,7 @@ for d in $PLUGINS; do
 		plugin="$(basename "$d")"
 		if [ $plugin != "windows" ]; then
 			echo "  $plugin"
-			$GO build -o "${PWD}/bin/$plugin" "$@" "$REPO_PATH"/$d
+			$GO build -tags no_openssl -o "${PWD}/bin/$plugin" "$@" "$REPO_PATH"/$d
 		fi
 	fi
 done


### PR DESCRIPTION
These plugins don't use any crypto so this change
disables openssl path completely for all plugins.

Obsoletes: pr#22

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>