### PR TITLE
Static IPAM plugin updates

### DIFF
--- a/plugins/ipam/static/README.md
+++ b/plugins/ipam/static/README.md
@@ -52,3 +52,7 @@ The following [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/
 * `GATEWAY`: request a specific gateway address
 
     (example: CNI_ARGS="IP=10.10.0.1/24;GATEWAY=10.10.0.254")
+
+The plugin also support following [capability argument](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md).
+
+* `ips`: Pass IP addresses for CNI interface

--- a/plugins/ipam/static/README.md
+++ b/plugins/ipam/static/README.md
@@ -60,3 +60,9 @@ The plugin also support following [capability argument](https://github.com/conta
 The following [args conventions](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#args-in-network-config) are supported:
 
 * `ips` (array of strings): A list of custom IPs to attempt to allocate, with prefix (e.g. '10.10.0.1/24')
+
+Notice: If some of above are used at same time, only one will work according to the priorities below
+
+1. [capability argument](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md)
+1. [args conventions](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#args-in-network-config)
+1. [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/SPEC.md#parameters)

--- a/plugins/ipam/static/README.md
+++ b/plugins/ipam/static/README.md
@@ -56,3 +56,7 @@ The following [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/
 The plugin also support following [capability argument](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md).
 
 * `ips`: Pass IP addresses for CNI interface
+
+The following [args conventions](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#args-in-network-config) are supported:
+
+* `ips` (array of strings): A list of custom IPs to attempt to allocate, with prefix (e.g. '10.10.0.1/24')

--- a/plugins/ipam/static/main.go
+++ b/plugins/ipam/static/main.go
@@ -38,6 +38,9 @@ type Net struct {
 	RuntimeConfig struct {
 		IPs []string `json:"ips,omitempty"`
 	} `json:"runtimeConfig,omitempty"`
+	Args *struct {
+		A *IPAMArgs `json:"cni"`
+	} `json:"args"`
 }
 
 type IPAMConfig struct {
@@ -52,6 +55,10 @@ type IPAMEnvArgs struct {
 	types.CommonArgs
 	IP      types.UnmarshallableString `json:"ip,omitempty"`
 	GATEWAY types.UnmarshallableString `json:"gateway,omitempty"`
+}
+
+type IPAMArgs struct {
+	IPs []string `json:"ips"`
 }
 
 type Address struct {
@@ -142,6 +149,15 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 		// args IP overwrites IP, so clear IPAM Config
 		n.IPAM.Addresses = make([]Address, 0, len(n.RuntimeConfig.IPs))
 		for _, addr := range n.RuntimeConfig.IPs {
+			n.IPAM.Addresses = append(n.IPAM.Addresses, Address{AddressStr: addr})
+		}
+	}
+
+	// import address from args
+	if n.Args != nil && n.Args.A != nil && len(n.Args.A.IPs) != 0 {
+		// args IP overwrites IP, so clear IPAM Config
+		n.IPAM.Addresses = make([]Address, 0, len(n.Args.A.IPs))
+		for _, addr := range n.Args.A.IPs {
 			n.IPAM.Addresses = append(n.IPAM.Addresses, Address{AddressStr: addr})
 		}
 	}

--- a/plugins/ipam/static/main.go
+++ b/plugins/ipam/static/main.go
@@ -145,11 +145,44 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 		return nil, "", err
 	}
 
-	if len(n.RuntimeConfig.IPs) != 0 {
-		// args IP overwrites IP, so clear IPAM Config
-		n.IPAM.Addresses = make([]Address, 0, len(n.RuntimeConfig.IPs))
-		for _, addr := range n.RuntimeConfig.IPs {
-			n.IPAM.Addresses = append(n.IPAM.Addresses, Address{AddressStr: addr})
+	// load IP from CNI_ARGS
+	if envArgs != "" {
+		e := IPAMEnvArgs{}
+		err := types.LoadArgs(envArgs, &e)
+		if err != nil {
+			return nil, "", err
+		}
+
+		if e.IP != "" {
+			for _, item := range strings.Split(string(e.IP), ",") {
+				ipstr := strings.TrimSpace(item)
+
+				ip, subnet, err := net.ParseCIDR(ipstr)
+				if err != nil {
+					return nil, "", fmt.Errorf("invalid CIDR %s: %s", ipstr, err)
+				}
+
+				addr := Address{
+					Address:    net.IPNet{IP: ip, Mask: subnet.Mask},
+					AddressStr: ipstr,
+				}
+				n.IPAM.Addresses = append(n.IPAM.Addresses, addr)
+			}
+		}
+
+		if e.GATEWAY != "" {
+			for _, item := range strings.Split(string(e.GATEWAY), ",") {
+				gwip := net.ParseIP(strings.TrimSpace(item))
+				if gwip == nil {
+					return nil, "", fmt.Errorf("invalid gateway address: %s", item)
+				}
+
+				for i := range n.IPAM.Addresses {
+					if n.IPAM.Addresses[i].Address.Contains(gwip) {
+						n.IPAM.Addresses[i].Gateway = gwip
+					}
+				}
+			}
 		}
 	}
 
@@ -158,6 +191,15 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 		// args IP overwrites IP, so clear IPAM Config
 		n.IPAM.Addresses = make([]Address, 0, len(n.Args.A.IPs))
 		for _, addr := range n.Args.A.IPs {
+			n.IPAM.Addresses = append(n.IPAM.Addresses, Address{AddressStr: addr})
+		}
+	}
+
+	// import address from runtimeConfig
+	if len(n.RuntimeConfig.IPs) != 0 {
+		// runtimeConfig IP overwrites IP, so clear IPAM Config
+		n.IPAM.Addresses = make([]Address, 0, len(n.RuntimeConfig.IPs))
+		for _, addr := range n.RuntimeConfig.IPs {
 			n.IPAM.Addresses = append(n.IPAM.Addresses, Address{AddressStr: addr})
 		}
 	}
@@ -188,50 +230,6 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 		} else {
 			n.IPAM.Addresses[i].Version = "6"
 			numV6++
-		}
-	}
-
-	if envArgs != "" {
-		e := IPAMEnvArgs{}
-		err := types.LoadArgs(envArgs, &e)
-		if err != nil {
-			return nil, "", err
-		}
-
-		if e.IP != "" {
-			for _, item := range strings.Split(string(e.IP), ",") {
-				ipstr := strings.TrimSpace(item)
-
-				ip, subnet, err := net.ParseCIDR(ipstr)
-				if err != nil {
-					return nil, "", fmt.Errorf("invalid CIDR %s: %s", ipstr, err)
-				}
-
-				addr := Address{Address: net.IPNet{IP: ip, Mask: subnet.Mask}}
-				if addr.Address.IP.To4() != nil {
-					addr.Version = "4"
-					numV4++
-				} else {
-					addr.Version = "6"
-					numV6++
-				}
-				n.IPAM.Addresses = append(n.IPAM.Addresses, addr)
-			}
-		}
-
-		if e.GATEWAY != "" {
-			for _, item := range strings.Split(string(e.GATEWAY), ",") {
-				gwip := net.ParseIP(strings.TrimSpace(item))
-				if gwip == nil {
-					return nil, "", fmt.Errorf("invalid gateway address: %s", item)
-				}
-
-				for i := range n.IPAM.Addresses {
-					if n.IPAM.Addresses[i].Address.Contains(gwip) {
-						n.IPAM.Addresses[i].Gateway = gwip
-					}
-				}
-			}
 		}
 	}
 

--- a/plugins/ipam/static/static_test.go
+++ b/plugins/ipam/static/static_test.go
@@ -265,6 +265,75 @@ var _ = Describe("static Operations", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("allocates and releases multiple addresses with ADD/DEL, from RuntimeConfig", func() {
+		const ifname string = "eth0"
+		const nspath string = "/some/where"
+
+		conf := `{
+			"cniVersion": "0.3.1",
+			"name": "mynet",
+			"type": "ipvlan",
+			"master": "foo0",
+			"capabilities": {"ips": true},
+			"ipam": {
+				"type": "static",
+				"routes": [
+				{ "dst": "0.0.0.0/0", "gw": "10.10.0.254" },
+				{ "dst": "3ffe:ffff:0:01ff::1/64",
+                                  "gw": "3ffe:ffff:0::1" } ],
+				  "dns": {
+					"nameservers" : ["8.8.8.8"],
+					"domain": "example.com",
+					"search": [ "example.com" ]
+			        }
+			},
+			"RuntimeConfig": {
+				"ips" : ["10.10.0.1/24", "3ffe:ffff:0:01ff::1/64"]
+			}
+		}`
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname,
+			StdinData:   []byte(conf),
+		}
+
+		// Allocate the IP
+		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
+			return cmdAdd(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Index(string(raw), "\"version\":")).Should(BeNumerically(">", 0))
+
+		result, err := current.GetResult(r)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Gomega is cranky about slices with different caps
+		Expect(*result.IPs[0]).To(Equal(
+			current.IPConfig{
+				Version: "4",
+				Address: mustCIDR("10.10.0.1/24"),
+			}))
+		Expect(*result.IPs[1]).To(Equal(
+			current.IPConfig{
+				Version: "6",
+				Address: mustCIDR("3ffe:ffff:0:01ff::1/64"),
+			},
+		))
+		Expect(len(result.IPs)).To(Equal(2))
+		Expect(result.Routes).To(Equal([]*types.Route{
+			{Dst: mustCIDR("0.0.0.0/0"), GW: net.ParseIP("10.10.0.254")},
+			{Dst: mustCIDR("3ffe:ffff:0:01ff::1/64"), GW: net.ParseIP("3ffe:ffff:0::1")},
+		}))
+
+		// Release the IP
+		err = testutils.CmdDelWithArgs(args, func() error {
+			return cmdDel(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
 })
 
 func mustCIDR(s string) net.IPNet {

--- a/plugins/ipam/static/static_test.go
+++ b/plugins/ipam/static/static_test.go
@@ -334,6 +334,76 @@ var _ = Describe("static Operations", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("allocates and releases multiple addresses with ADD/DEL, from args", func() {
+		const ifname string = "eth0"
+		const nspath string = "/some/where"
+
+		conf := `{
+			"cniVersion": "0.3.1",
+			"name": "mynet",
+			"type": "ipvlan",
+			"master": "foo0",
+			"ipam": {
+				"type": "static",
+				"routes": [
+				{ "dst": "0.0.0.0/0", "gw": "10.10.0.254" },
+				{ "dst": "3ffe:ffff:0:01ff::1/64",
+                                  "gw": "3ffe:ffff:0::1" } ],
+				  "dns": {
+					"nameservers" : ["8.8.8.8"],
+					"domain": "example.com",
+					"search": [ "example.com" ]
+			        }
+			},
+			"args": {
+				"cni": {
+					"ips" : ["10.10.0.1/24", "3ffe:ffff:0:01ff::1/64"]
+			        }
+			}
+		}`
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname,
+			StdinData:   []byte(conf),
+		}
+
+		// Allocate the IP
+		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
+			return cmdAdd(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Index(string(raw), "\"version\":")).Should(BeNumerically(">", 0))
+
+		result, err := current.GetResult(r)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Gomega is cranky about slices with different caps
+		Expect(*result.IPs[0]).To(Equal(
+			current.IPConfig{
+				Version: "4",
+				Address: mustCIDR("10.10.0.1/24"),
+			}))
+		Expect(*result.IPs[1]).To(Equal(
+			current.IPConfig{
+				Version: "6",
+				Address: mustCIDR("3ffe:ffff:0:01ff::1/64"),
+			},
+		))
+		Expect(len(result.IPs)).To(Equal(2))
+		Expect(result.Routes).To(Equal([]*types.Route{
+			{Dst: mustCIDR("0.0.0.0/0"), GW: net.ParseIP("10.10.0.254")},
+			{Dst: mustCIDR("3ffe:ffff:0:01ff::1/64"), GW: net.ParseIP("3ffe:ffff:0::1")},
+		}))
+
+		// Release the IP
+		err = testutils.CmdDelWithArgs(args, func() error {
+			return cmdDel(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
 })
 
 func mustCIDR(s string) net.IPNet {

--- a/plugins/meta/tuning/README.md
+++ b/plugins/meta/tuning/README.md
@@ -64,3 +64,10 @@ Note: You may add `IgnoreUnknown=true` to allow loose CNI argument verification 
 The plugin also support following [capability argument](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md).
 
 * `mac`: Pass MAC addresses for CNI interface
+
+The following [args conventions](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#args-in-network-config) are supported:
+
+* `mac` (string, optional): MAC address (i.e. hardware address) of interface
+* `mtu` (integer, optional): MTU of interface
+* `promisc` (bool, optional): Change the promiscuous mode of interface
+* `sysctl` (object, optional): Change system controls

--- a/plugins/meta/tuning/README.md
+++ b/plugins/meta/tuning/README.md
@@ -61,3 +61,6 @@ The following [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/
 
 Note: You may add `IgnoreUnknown=true` to allow loose CNI argument verification (see CNI's issue[#560](https://github.com/containernetworking/cni/issues/560)).
 
+The plugin also support following [capability argument](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md).
+
+* `mac`: Pass MAC addresses for CNI interface

--- a/plugins/meta/tuning/tuning.go
+++ b/plugins/meta/tuning/tuning.go
@@ -47,6 +47,16 @@ type TuningConf struct {
 	RuntimeConfig struct {
 		Mac string `json:"mac,omitempty"`
 	} `json:"runtimeConfig,omitempty"`
+	Args *struct {
+		A *IPAMArgs `json:"cni"`
+	} `json:"args"`
+}
+
+type IPAMArgs struct {
+	SysCtl  *map[string]string `json:"sysctl"`
+	Mac     *string            `json:"mac,omitempty"`
+	Promisc *bool              `json:"promisc,omitempty"`
+	Mtu     *int               `json:"mtu,omitempty"`
 }
 
 // MacEnvArgs represents CNI_ARG
@@ -77,6 +87,28 @@ func parseConf(data []byte, envArgs string) (*TuningConf, error) {
 	// Parse custom Mac from RuntimeConfig
 	if conf.RuntimeConfig.Mac != "" {
 		conf.Mac = conf.RuntimeConfig.Mac
+	}
+
+	// Get args
+	if conf.Args != nil && conf.Args.A != nil {
+		if conf.Args.A.SysCtl != nil {
+			for k, v := range *conf.Args.A.SysCtl {
+				conf.SysCtl[k] = v
+			}
+		}
+
+		if conf.Args.A.Mac != nil {
+			conf.Mac = *conf.Args.A.Mac
+		}
+
+		if conf.Args.A.Promisc != nil {
+			conf.Promisc = *conf.Args.A.Promisc
+		}
+
+		if conf.Args.A.Mtu != nil {
+			conf.Mtu = *conf.Args.A.Mtu
+		}
+
 	}
 
 	return &conf, nil

--- a/plugins/meta/tuning/tuning_test.go
+++ b/plugins/meta/tuning/tuning_test.go
@@ -379,6 +379,7 @@ var _ = Describe("tuning plugin", func() {
 			Expect(err).NotTo(HaveOccurred())
 			hw, err := net.ParseMAC("c2:11:22:33:44:66")
 			Expect(err).NotTo(HaveOccurred())
+			fmt.Printf("%v, %v\n", link.Attrs().HardwareAddr, hw)
 			Expect(link.Attrs().HardwareAddr).To(Equal(hw))
 
 			err = testutils.CmdDel(originalNS.Path(),
@@ -681,4 +682,67 @@ var _ = Describe("tuning plugin", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("configures and deconfigures mac address (from RuntimeConfig) with ADD/DEL", func() {
+		conf := []byte(`{
+	"name": "test",
+	"type": "iplink",
+	"cniVersion": "0.3.1",
+        "capabilities": {"mac": true},
+        "RuntimeConfig": {
+            "mac": "c2:11:22:33:44:55"
+        },
+	"prevResult": {
+		"interfaces": [
+			{"name": "dummy0", "sandbox":"netns"}
+		],
+		"ips": [
+			{
+				"version": "4",
+				"address": "10.0.0.2/24",
+				"gateway": "10.0.0.1",
+				"interface": 0
+			}
+		]
+	}
+}`)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       originalNS.Path(),
+			IfName:      IFNAME,
+			StdinData:   conf,
+		}
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(1))
+			Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+			Expect(len(result.IPs)).To(Equal(1))
+			Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			hw, err := net.ParseMAC("c2:11:22:33:44:55")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().HardwareAddr).To(Equal(hw))
+
+			err = testutils.CmdDel(originalNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 })

--- a/plugins/meta/tuning/tuning_test.go
+++ b/plugins/meta/tuning/tuning_test.go
@@ -215,6 +215,67 @@ var _ = Describe("tuning plugin", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("configures and deconfigures promiscuous mode from args with ADD/DEL", func() {
+		conf := []byte(`{
+	"name": "test",
+	"type": "iplink",
+	"cniVersion": "0.3.1",
+        "args": {
+            "cni": {
+	        "promisc": true
+            }
+        },
+	"prevResult": {
+		"interfaces": [
+			{"name": "dummy0", "sandbox":"netns"}
+		],
+		"ips": [
+			{
+				"version": "4",
+				"address": "10.0.0.2/24",
+				"gateway": "10.0.0.1",
+				"interface": 0
+			}
+		]
+	}
+}`)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       originalNS.Path(),
+			IfName:      IFNAME,
+			StdinData:   conf,
+		}
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(1))
+			Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+			Expect(len(result.IPs)).To(Equal(1))
+			Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Promisc).To(Equal(1))
+
+			err = testutils.CmdDel(originalNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("configures and deconfigures mtu with ADD/DEL", func() {
 		conf := []byte(`{
 	"name": "test",
@@ -272,12 +333,136 @@ var _ = Describe("tuning plugin", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("configures and deconfigures mtu from args with ADD/DEL", func() {
+		conf := []byte(`{
+	"name": "test",
+	"type": "iplink",
+	"cniVersion": "0.3.1",
+        "args": {
+            "cni": {
+                "mtu": 1454
+            }
+        },
+	"prevResult": {
+		"interfaces": [
+			{"name": "dummy0", "sandbox":"netns"}
+		],
+		"ips": [
+			{
+				"version": "4",
+				"address": "10.0.0.2/24",
+				"gateway": "10.0.0.1",
+				"interface": 0
+			}
+		]
+	}
+}`)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       originalNS.Path(),
+			IfName:      IFNAME,
+			StdinData:   conf,
+		}
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(1))
+			Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+			Expect(len(result.IPs)).To(Equal(1))
+			Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().MTU).To(Equal(1454))
+
+			err = testutils.CmdDel(originalNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("configures and deconfigures mac address (from conf file) with ADD/DEL", func() {
 		conf := []byte(`{
 	"name": "test",
 	"type": "iplink",
 	"cniVersion": "0.3.1",
 	"mac": "c2:11:22:33:44:55",
+	"prevResult": {
+		"interfaces": [
+			{"name": "dummy0", "sandbox":"netns"}
+		],
+		"ips": [
+			{
+				"version": "4",
+				"address": "10.0.0.2/24",
+				"gateway": "10.0.0.1",
+				"interface": 0
+			}
+		]
+	}
+}`)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       originalNS.Path(),
+			IfName:      IFNAME,
+			StdinData:   conf,
+		}
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(1))
+			Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+			Expect(len(result.IPs)).To(Equal(1))
+			Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			hw, err := net.ParseMAC("c2:11:22:33:44:55")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().HardwareAddr).To(Equal(hw))
+
+			err = testutils.CmdDel(originalNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("configures and deconfigures mac address (from args) with ADD/DEL", func() {
+		conf := []byte(`{
+	"name": "test",
+	"type": "iplink",
+	"cniVersion": "0.3.1",
+        "args": {
+            "cni": {
+                "mac": "c2:11:22:33:44:55"
+            }
+        },
 	"prevResult": {
 		"interfaces": [
 			{"name": "dummy0", "sandbox":"netns"}


### PR DESCRIPTION
Contains three commits for:

* introduces new capability flag to change MAC address and to specify IP addresses by tuning and static
* Support "args" field in JSON config to additional configuration in static and tuning plugins.
* introduce priorities for IPs input among CNI_ARGS, 'args' and runtimeConfig