### PR TITLE
Dockerfile: build Windows plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,23 @@ RUN ./build_linux.sh && \
     cd /usr/src/plugins/bin
 WORKDIR /
 
+FROM openshift/origin-release:rhel-8-golang-1.12 as windows
+ADD . /usr/src/plugins
+WORKDIR /usr/src/plugins
+ENV CGO_ENABLED=0
+RUN ./build_windows.sh && \
+    cd /usr/src/plugins/bin
+WORKDIR /
+
 FROM openshift/origin-base
 RUN mkdir -p /usr/src/plugins/bin && \
     mkdir -p /usr/src/plugins/rhel7/bin && \
-    mkdir -p /usr/src/plugins/rhel8/bin
+    mkdir -p /usr/src/plugins/rhel8/bin && \
+    mkdir -p /usr/src/plugins/windows/bin
 COPY --from=rhel7 /usr/src/plugins/bin/* /usr/src/plugins/rhel7/bin/
 COPY --from=rhel8 /usr/src/plugins/bin/* /usr/src/plugins/bin/
 COPY --from=rhel8 /usr/src/plugins/bin/* /usr/src/plugins/rhel8/bin/
+COPY --from=windows /usr/src/plugins/bin/* /usr/src/plugins/windows/bin/
 
 LABEL io.k8s.display-name="Container Networking Plugins" \
       io.k8s.description="This is a component of OpenShift Container Platform and provides the reference CNI plugins." \


### PR DESCRIPTION
Add building of Windows plugin binaries into the image. These binaries will be used by the [Windows Machine Config Operator](https://github.com/openshift/windows-machine-config-operator/) as part of preparing a VM to become an OpenShift worker node.

Signed-off-by: Aravindh Puthiyaparambil <aravindh@redhat.com>