### PR TITLE
Fix build of Windows binaries when run on other architectures

### DIFF
--- a/build_windows.sh
+++ b/build_windows.sh
@@ -11,6 +11,7 @@ trap "{ rm -rf $GOPATH; }" EXIT
 ln -s ${PWD} ${GOPATH}/src/${REPO_PATH} || exit 255
 
 export GO="${GO:-go}"
+export GOARCH=amd64
 export GOOS=windows
 export GOFLAGS="${GOFLAGS} -mod=vendor"
 echo $GOFLAGS


### PR DESCRIPTION
This fixes multi-arch builds of this container image after 
https://github.com/openshift/containernetworking-plugins/pull/30 .