### PR TITLE
Bug 1879244: ipvlan - make master config as optional

### DIFF
--- a/plugins/main/ipvlan/README.md
+++ b/plugins/main/ipvlan/README.md
@@ -27,7 +27,7 @@ Because all ipvlan interfaces share the MAC address with the host interface, DHC
 
 * `name` (string, required): the name of the network.
 * `type` (string, required): "ipvlan".
-* `master` (string, required unless chained): name of the host interface to enslave.
+* `master` (string, optional): name of the host interface to enslave. Defaults to default route interface.
 * `mode` (string, optional): one of "l2", "l3", "l3s". Defaults to "l2".
 * `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
 * `ipam` (dictionary, required unless chained): IPAM configuration to be used for this network.


### PR DESCRIPTION
This change makes ipvlan master parameter optional.
Default to default route interface as macvlan does.

Signed-off-by: Tomofumi Hayashi <tohayash@redhat.com>