### PR TITLE
Bug 1989342: host-device: Add support for DPDK device

### DIFF
--- a/plugins/main/host-device/host-device.go
+++ b/plugins/main/host-device/host-device.go
@@ -43,6 +43,9 @@ const (
 	sysBusPCI = "/sys/bus/pci/devices"
 )
 
+// Array of different linux drivers bound to network device needed for DPDK
+var userspaceDrivers = []string{"vfio-pci", "uio_pci_generic", "igb_uio"}
+
 //NetConf for host-device config, look the README to learn how to use those parameters
 type NetConf struct {
 	types.NetConf
@@ -90,6 +93,16 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
 	}
 	defer containerNs.Close()
+
+	if len(cfg.PCIAddr) > 0 {
+		isDpdkMode, err := hasDpdkDriver(cfg.PCIAddr)
+		if err != nil {
+			return fmt.Errorf("error with host device: %v", err)
+		}
+		if isDpdkMode {
+			return types.PrintResult(&current.Result{}, cfg.CNIVersion)
+		}
+	}
 
 	hostDev, err := getLink(cfg.Device, cfg.HWAddr, cfg.KernelPath, cfg.PCIAddr)
 	if err != nil {
@@ -167,6 +180,16 @@ func cmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
 	}
 	defer containerNs.Close()
+
+	if len(cfg.PCIAddr) > 0 {
+		isDpdkMode, err := hasDpdkDriver(cfg.PCIAddr)
+		if err != nil {
+			return fmt.Errorf("error with host device: %v", err)
+		}
+		if isDpdkMode {
+			return nil
+		}
+	}
 
 	if err := moveLinkOut(containerNs, args.IfName); err != nil {
 		return err
@@ -253,6 +276,25 @@ func moveLinkOut(containerNs ns.NetNS, ifName string) error {
 		}
 		return nil
 	})
+}
+
+func hasDpdkDriver(pciaddr string) (bool, error) {
+	driverLink := filepath.Join(sysBusPCI, pciaddr, "driver")
+	driverPath, err := filepath.EvalSymlinks(driverLink)
+	if err != nil {
+		return false, err
+	}
+	driverStat, err := os.Stat(driverPath)
+	if err != nil {
+		return false, err
+	}
+	driverName := driverStat.Name()
+	for _, drv := range userspaceDrivers {
+		if driverName == drv {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func printLink(dev netlink.Link, cniVersion string, containerNs ns.NetNS) error {


### PR DESCRIPTION
This commit would make host-device plugin as a placeholder
for DPDK device when applications wants to attach it with
a pod container through network attachment definition.

Merges changes from https://github.com/containernetworking/plugins/pull/490