### PR TITLE
OCPBUGS-5292: Revert "Fix path substitution to enable setting sysctls on vlan interfaces" (ocp 4.13)

### DIFF
--- a/plugins/meta/tuning/tuning.go
+++ b/plugins/meta/tuning/tuning.go
@@ -316,10 +316,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	if err = validateArgs(args); err != nil {
-		return err
-	}
-
 	// Parse previous result.
 	if tuningConf.RawPrevResult == nil {
 		return fmt.Errorf("Required prevResult missing")
@@ -334,14 +330,12 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	err = ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
 		for key, value := range tuningConf.SysCtl {
-			key = strings.Replace(key, ".", string(os.PathSeparator), -1)
-
 			// If the key contains `IFNAME` - substitute it with args.IfName
 			// to allow setting sysctls on a particular interface, on which
 			// other operations (like mac/mtu setting) are performed
 			key = strings.Replace(key, "IFNAME", args.IfName, 1)
 
-			fileName := filepath.Join("/proc/sys", key)
+			fileName := filepath.Join("/proc/sys", strings.Replace(key, ".", "/", -1))
 
 			// Refuse to modify sysctl parameters that don't belong
 			// to the network subsystem.
@@ -575,11 +569,4 @@ func (d *sysctlKey) UnmarshalText(data []byte) error {
 func validateSysctlConflictingKeys(data []byte) error {
 	sysctlCheck := sysctlCheck{}
 	return json.Unmarshal(data, &sysctlCheck)
-}
-
-func validateArgs(args *skel.CmdArgs) error {
-	if strings.Contains(args.Args, string(os.PathSeparator)) {
-		return errors.New(fmt.Sprintf("Interface name contains an invalid character %s", string(os.PathSeparator)))
-	}
-	return nil
 }


### PR DESCRIPTION
Which causes a regression related to https://issues.redhat.com/browse/OCPBUGS-5289

This reverts commit 198ab129a153dd9077d3f78d2eb3ee7d1ab72b0f.