### PR TITLE
OCPBUGS-17681: Default CNI binaries to RHEL 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN mkdir -p /usr/src/plugins/bin && \
     mkdir -p /usr/src/plugins/rhel9/bin && \
     mkdir -p /usr/src/plugins/windows/bin
 COPY --from=rhel8 /usr/src/plugins/bin/* /usr/src/plugins/rhel8/bin/
-COPY --from=rhel9 /usr/src/plugins/bin/* /usr/src/plugins/bin/
+# pod container image is RHEL8 based, so use rhel8
+COPY --from=rhel8 /usr/src/plugins/bin/* /usr/src/plugins/bin/
 COPY --from=rhel9 /usr/src/plugins/bin/* /usr/src/plugins/rhel9/bin/
 COPY --from=windows /usr/src/plugins/bin/* /usr/src/plugins/windows/bin/
 


### PR DESCRIPTION
Base container image registry.ci.openshift.org/ocp/4.14:base is RHEL 8.6. Use the RHEL 8 built CNI binaries instead of the RHEL 9 ones.

The observed error is Pods in CrashLoopBackOff state and failing with:
  /usr/src/plugins/bin/dhcp: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /usr/src/plugins/bin/dhcp)