### PR TITLE
OKD-218: install util-linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN ./build_windows.sh && \
 WORKDIR /
 
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
-RUN mkdir -p /usr/src/plugins/bin && \
+RUN dnf install -y util-linux && dnf clean all && \
+    mkdir -p /usr/src/plugins/bin && \
     mkdir -p /usr/src/plugins/rhel8/bin && \
     mkdir -p /usr/src/plugins/rhel9/bin && \
     mkdir -p /usr/src/plugins/windows/bin

--- a/Dockerfile.microshift
+++ b/Dockerfile.microshift
@@ -7,7 +7,8 @@ RUN ./build_linux.sh
 WORKDIR /
 
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
-RUN mkdir -p /usr/src/plugins/bin
+RUN dnf install -y util-linux && dnf clean all && \
+    mkdir -p /usr/src/plugins/bin
 COPY --from=rhel9 \
   /usr/src/plugins/bin/bridge \
   /usr/src/plugins/bin/macvlan \


### PR DESCRIPTION
Similar to https://github.com/openshift/egress-router-cni/pull/82. Needed for OKD installs to succeed.
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-okd-scos-4.16-e2e-aws-ovn/1798613975458385920/artifacts/e2e-aws-ovn/gather-extra/artifacts/pods.json shows the failing containers with this error.