### PR TITLE
OCPBUGS-55346: Check error returned by ipv6 SettleAddresses

### DIFF
--- a/pkg/ip/addr_linux.go
+++ b/pkg/ip/addr_linux.go
@@ -29,15 +29,15 @@ const SETTLE_INTERVAL = 50 * time.Millisecond
 // There is no easy way to wait for this as an event, so just loop until the
 // addresses are no longer tentative.
 // If any addresses are still tentative after timeout seconds, then error.
-func SettleAddresses(ifName string, timeout int) error {
+func SettleAddresses(ifName string, timeout time.Duration) error {
 	link, err := netlink.LinkByName(ifName)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve link: %v", err)
 	}
 
-	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
+	deadline := time.Now().Add(timeout)
 	for {
-		addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V6)
 		if err != nil {
 			return fmt.Errorf("could not list addresses: %v", err)
 		}
@@ -48,7 +48,13 @@ func SettleAddresses(ifName string, timeout int) error {
 
 		ok := true
 		for _, addr := range addrs {
-			if addr.Flags&(syscall.IFA_F_TENTATIVE|syscall.IFA_F_DADFAILED) > 0 {
+			if addr.Flags&(syscall.IFA_F_DADFAILED) != 0 {
+				return fmt.Errorf("link %s has address %s in DADFAILED state",
+					ifName,
+					addr.IP.String())
+			}
+
+			if addr.Flags&(syscall.IFA_F_TENTATIVE) != 0 {
 				ok = false
 				break // Break out of the `range addrs`, not the `for`
 			}

--- a/pkg/ipam/ipam_linux.go
+++ b/pkg/ipam/ipam_linux.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 
 	"github.com/vishvananda/netlink"
 
@@ -29,6 +30,8 @@ import (
 const (
 	// Note: use slash as separator so we can have dots in interface name (VLANs)
 	DisableIPv6SysctlTemplate = "net/ipv6/conf/%s/disable_ipv6"
+
+	dadSettleTimeout = 5 * time.Second
 )
 
 // ConfigureIface takes the result of IPAM plugin and
@@ -100,7 +103,10 @@ func ConfigureIface(ifName string, res *current.Result) error {
 	}
 
 	if v6gw != nil {
-		ip.SettleAddresses(ifName, 10)
+		err = ip.SettleAddresses(ifName, dadSettleTimeout)
+		if err != nil {
+			return fmt.Errorf("failed to settle addresses for %q: %v", ifName, err)
+		}
 	}
 
 	for _, r := range res.Routes {


### PR DESCRIPTION
IPv6 configuration is valid if DAD does not fail