### PR TITLE
Add a new firewall ingress-policy "isolated"

### DIFF
--- a/plugins/meta/firewall/firewall.go
+++ b/plugins/meta/firewall/firewall.go
@@ -64,6 +64,13 @@ const (
 	// IngressPolicySameBridge executes `iptables` regardless to the value of `Backend`.
 	// IngressPolicySameBridge may not work as expected for non-bridge networks.
 	IngressPolicySameBridge IngressPolicy = "same-bridge"
+
+	// IngressPolicyIsolated ("isolated"): similar to ingress policy "same-bridge" with the exception
+	// that connections from the same bridge are also blocked.
+	// This is equivalent to Docker network option "enable_icc" when set to false.
+	// IngressPolicyIsolated executes `iptables` regardless to the value of `Backend`.
+	// IngressPolicyIsolated may not work as expected for non-bridge networks.
+	IngressPolicyIsolated IngressPolicy = "isolated"
 )
 
 type FirewallBackend interface {


### PR DESCRIPTION
Clean Backport of Port-isolation feature

Add a new firewall ingress-policy "isolated"
IngressPolicyIsolated ("isolated") behaves similar to ingress policy "same-bridge" with the exception
that connections from the same bridge are also blocked. This is meant to be functionally equivalent
to Docker network option "enable_icc" when set to false.
