### PR TITLE
bridge: Add option to enable port isolation

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -61,6 +61,7 @@ type NetConf struct {
 	MacSpoofChk               bool         `json:"macspoofchk,omitempty"`
 	EnableDad                 bool         `json:"enabledad,omitempty"`
 	DisableContainerInterface bool         `json:"disableContainerInterface,omitempty"`
+	PortIsolation             bool         `json:"portIsolation,omitempty"`
 
 	Args struct {
 		Cni BridgeArgs `json:"cni,omitempty"`
@@ -392,7 +393,7 @@ func ensureVlanInterface(br *netlink.Bridge, vlanID int, preserveDefaultVlan boo
 			return nil, fmt.Errorf("faild to find host namespace: %v", err)
 		}
 
-		_, brGatewayIface, err := setupVeth(hostNS, br, name, br.MTU, false, vlanID, nil, preserveDefaultVlan, "")
+		_, brGatewayIface, err := setupVeth(hostNS, br, name, br.MTU, false, vlanID, nil, preserveDefaultVlan, "", false)
 		if err != nil {
 			return nil, fmt.Errorf("faild to create vlan gateway %q: %v", name, err)
 		}
@@ -411,7 +412,18 @@ func ensureVlanInterface(br *netlink.Bridge, vlanID int, preserveDefaultVlan boo
 	return brGatewayVeth, nil
 }
 
-func setupVeth(netns ns.NetNS, br *netlink.Bridge, ifName string, mtu int, hairpinMode bool, vlanID int, vlans []int, preserveDefaultVlan bool, mac string) (*current.Interface, *current.Interface, error) {
+func setupVeth(
+	netns ns.NetNS,
+	br *netlink.Bridge,
+	ifName string,
+	mtu int,
+	hairpinMode bool,
+	vlanID int,
+	vlans []int,
+	preserveDefaultVlan bool,
+	mac string,
+	portIsolation bool,
+) (*current.Interface, *current.Interface, error) {
 	contIface := &current.Interface{}
 	hostIface := &current.Interface{}
 
@@ -446,6 +458,11 @@ func setupVeth(netns ns.NetNS, br *netlink.Bridge, ifName string, mtu int, hairp
 	// set hairpin mode
 	if err = netlink.LinkSetHairpin(hostVeth, hairpinMode); err != nil {
 		return nil, nil, fmt.Errorf("failed to setup hairpin mode for %v: %v", hostVeth.Attrs().Name, err)
+	}
+
+	// set isolation mode
+	if err = netlink.LinkSetIsolated(hostVeth, portIsolation); err != nil {
+		return nil, nil, fmt.Errorf("failed to set isolated on for %v: %v", hostVeth.Attrs().Name, err)
 	}
 
 	if (vlanID != 0 || len(vlans) > 0) && !preserveDefaultVlan {
@@ -554,7 +571,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	defer netns.Close()
 
-	hostInterface, containerInterface, err := setupVeth(netns, br, args.IfName, n.MTU, n.HairpinMode, n.Vlan, n.vlans, n.PreserveDefaultVlan, n.mac)
+	hostInterface, containerInterface, err := setupVeth(netns, br, args.IfName, n.MTU, n.HairpinMode, n.Vlan, n.vlans, n.PreserveDefaultVlan, n.mac, n.PortIsolation)
 	if err != nil {
 		return err
 	}

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -79,6 +79,7 @@ type testCase struct {
 	ipMasq            bool
 	macspoofchk       bool
 	disableContIface  bool
+	portIsolation     bool
 
 	AddErr020 string
 	DelErr020 string
@@ -158,6 +159,9 @@ const (
 
 	disableContainerInterface = `,
     "disableContainerInterface": true`
+
+	portIsolation = `,
+    "portIsolation": true`
 
 	ipamStartStr = `,
     "ipam": {
@@ -255,6 +259,10 @@ func (tc testCase) netConfJSON(dataDir string) string {
 
 	if tc.disableContIface {
 		conf += disableContainerInterface
+	}
+
+	if tc.portIsolation {
+		conf += portIsolation
 	}
 
 	if !tc.isLayer2 {
@@ -629,6 +637,10 @@ func (tester *testerV10x) cmdAddTest(tc testCase, dataDir string) (types.Result,
 		Expect(err).NotTo(HaveOccurred())
 		Expect(link).To(BeAssignableToTypeOf(&netlink.Veth{}))
 		tester.vethName = result.Interfaces[1].Name
+
+		protInfo, err := netlink.LinkGetProtinfo(link)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(protInfo.Isolated).To(Equal(tc.portIsolation), "link isolation should be on when portIsolation is set")
 
 		// check vlan exist on the veth interface
 		if tc.vlan != 0 {
@@ -2515,6 +2527,36 @@ var _ = Describe("bridge Operations", func() {
 					isLayer2:         true,
 					AddErr020:        "cannot convert: no valid IP addresses",
 					AddErr010:        "cannot convert: no valid IP addresses",
+				}
+				cmdAddDelTest(originalNS, targetNS, tc, dataDir)
+				return nil
+			})).To(Succeed())
+		})
+
+		It(fmt.Sprintf("[%s] when port-isolation is off, should set the veth peer on node with isolation off", ver), func() {
+			Expect(originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				tc := testCase{
+					cniVersion:    ver,
+					portIsolation: false,
+					isLayer2:      true,
+					AddErr020:     "cannot convert: no valid IP addresses",
+					AddErr010:     "cannot convert: no valid IP addresses",
+				}
+				cmdAddDelTest(originalNS, targetNS, tc, dataDir)
+				return nil
+			})).To(Succeed())
+		})
+
+		It(fmt.Sprintf("[%s] when port-isolation is on, should set the veth peer on node with isolation on", ver), func() {
+			Expect(originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				tc := testCase{
+					cniVersion:    ver,
+					portIsolation: true,
+					isLayer2:      true,
+					AddErr020:     "cannot convert: no valid IP addresses",
+					AddErr010:     "cannot convert: no valid IP addresses",
 				}
 				cmdAddDelTest(originalNS, targetNS, tc, dataDir)
 				return nil


### PR DESCRIPTION
Clean backport of port isolation

Enable bridge CNI plugin setting port-isolation [1] the interface. When port-isolation is enabled, containers connected to the network cannot communicate with each other over the linux-bridge. Communication will be enable depending on the gateway appliance according to its restrictions / policies.

For example: in a scenario the env connected to smart switch, enabling port-isolation ensure traffic will go outbound, allowing the smart-switch routing the traffic according to policies.

Add "portIsolation" flag to bridge plugin.
When true, configure the node interface with port-isolation [1]. Default is false.

[1] https://man7.org/linux/man-pages/man8/bridge.8.html (see "isolated" option)


(cherry picked from commit 7c122fabb4e0c81034b653ccc943379ffa90e405)