### PR TITLE
OCPBUGS-60871: [release-4.18] host-device: Return interface name in result

### DIFF
--- a/plugins/main/host-device/host-device.go
+++ b/plugins/main/host-device/host-device.go
@@ -100,6 +100,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 	defer containerNs.Close()
 
 	result := &current.Result{}
+	result.Interfaces = []*current.Interface{{
+		Name:    args.IfName,
+		Sandbox: containerNs.Path(),
+	}}
+
 	var contDev netlink.Link
 	if !cfg.DPDKMode {
 		hostDev, err := getLink(cfg.Device, cfg.HWAddr, cfg.KernelPath, cfg.PCIAddr)
@@ -112,11 +117,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 			return fmt.Errorf("failed to move link %v", err)
 		}
 
-		result.Interfaces = []*current.Interface{{
-			Name:    contDev.Attrs().Name,
-			Mac:     contDev.Attrs().HardwareAddr.String(),
-			Sandbox: containerNs.Path(),
-		}}
+		// Override the device name with the name in the container namespace
+		result.Interfaces[0].Name = contDev.Attrs().Name
+		// Set the MAC address of the interface
+		result.Interfaces[0].Mac = contDev.Attrs().HardwareAddr.String()
 	}
 
 	if cfg.IPAM.Type == "" {

--- a/plugins/main/host-device/host-device_test.go
+++ b/plugins/main/host-device/host-device_test.go
@@ -218,7 +218,7 @@ func buildOneConfig(name, cniVersion string, orig *Net, prevResult types.Result)
 
 type tester interface {
 	expectInterfaces(result types.Result, name, mac, sandbox string)
-	expectDpdkInterfaceIP(result types.Result, ipAddress string)
+	expectDpdkInterfaceIP(result types.Result, name, sandbox, ipAddress string)
 }
 
 type testerBase struct{}
@@ -256,11 +256,16 @@ func (t *testerV10x) expectInterfaces(result types.Result, name, mac, sandbox st
 	}))
 }
 
-func (t *testerV10x) expectDpdkInterfaceIP(result types.Result, ipAddress string) {
+func (t *testerV10x) expectDpdkInterfaceIP(result types.Result, name, sandbox, ipAddress string) {
 	// check that the result was sane
 	res, err := types100.NewResultFromResult(result)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(res.Interfaces).To(BeEmpty())
+	Expect(res.Interfaces).To(Equal([]*types100.Interface{
+		{
+			Name:    name,
+			Sandbox: sandbox,
+		},
+	}))
 	Expect(res.IPs).To(HaveLen(1))
 	Expect(res.IPs[0].Address.String()).To(Equal(ipAddress))
 }
@@ -278,11 +283,16 @@ func (t *testerV04x) expectInterfaces(result types.Result, name, mac, sandbox st
 	}))
 }
 
-func (t *testerV04x) expectDpdkInterfaceIP(result types.Result, ipAddress string) {
+func (t *testerV04x) expectDpdkInterfaceIP(result types.Result, name, sandbox, ipAddress string) {
 	// check that the result was sane
 	res, err := types040.NewResultFromResult(result)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(res.Interfaces).To(BeEmpty())
+	Expect(res.Interfaces).To(Equal([]*types040.Interface{
+		{
+			Name:    name,
+			Sandbox: sandbox,
+		},
+	}))
 	Expect(res.IPs).To(HaveLen(1))
 	Expect(res.IPs[0].Address.String()).To(Equal(ipAddress))
 }
@@ -300,11 +310,16 @@ func (t *testerV03x) expectInterfaces(result types.Result, name, mac, sandbox st
 	}))
 }
 
-func (t *testerV03x) expectDpdkInterfaceIP(result types.Result, ipAddress string) {
+func (t *testerV03x) expectDpdkInterfaceIP(result types.Result, name, sandbox, ipAddress string) {
 	// check that the result was sane
 	res, err := types040.NewResultFromResult(result)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(res.Interfaces).To(BeEmpty())
+	Expect(res.Interfaces).To(Equal([]*types040.Interface{
+		{
+			Name:    name,
+			Sandbox: sandbox,
+		},
+	}))
 	Expect(res.IPs).To(HaveLen(1))
 	Expect(res.IPs[0].Address.String()).To(Equal(ipAddress))
 }
@@ -589,7 +604,7 @@ var _ = Describe("base functionality", func() {
 
 			// check that the result was sane
 			t := newTesterByVersion(ver)
-			t.expectDpdkInterfaceIP(resI, targetIP)
+			t.expectDpdkInterfaceIP(resI, cniName, targetNS.Path(), targetIP)
 
 			// call CmdDel
 			_ = originalNS.Do(func(ns.NetNS) error {
@@ -861,7 +876,7 @@ var _ = Describe("base functionality", func() {
 
 			// check that the result was sane
 			t := newTesterByVersion(ver)
-			t.expectDpdkInterfaceIP(resI, targetIP)
+			t.expectDpdkInterfaceIP(resI, cniName, targetNS.Path(), targetIP)
 
 			// call CmdCheck
 			n := &Net{}


### PR DESCRIPTION
4.18 backport of
- https://github.com/containernetworking/plugins/pull/1147