### PR TITLE
OCPBUGS-83863: Remove rhel8 build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,7 @@ RUN ./build_linux.sh && \
     cd /usr/src/plugins/bin
 WORKDIR /
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22 AS rhel8
-COPY . /usr/src/plugins
-WORKDIR /usr/src/plugins
-ENV CGO_ENABLED=0
-RUN ./build_linux.sh && \
-    cd /usr/src/plugins/bin
-WORKDIR /
-
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22 AS windows
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS windows
 COPY . /usr/src/plugins
 WORKDIR /usr/src/plugins
 ENV CGO_ENABLED=0
@@ -25,12 +17,9 @@ WORKDIR /
 
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 RUN mkdir -p /usr/src/plugins/bin && \
-    mkdir -p /usr/src/plugins/rhel8/bin && \
     mkdir -p /usr/src/plugins/rhel9/bin && \
     mkdir -p /usr/src/plugins/windows/bin
-COPY --from=rhel8 /usr/src/plugins/bin/* /usr/src/plugins/rhel8/bin/
-# pod container image is RHEL8 based, so use rhel8
-COPY --from=rhel8 /usr/src/plugins/bin/* /usr/src/plugins/bin/
+COPY --from=rhel9 /usr/src/plugins/bin/* /usr/src/plugins/bin/
 COPY --from=rhel9 /usr/src/plugins/bin/* /usr/src/plugins/rhel9/bin/
 COPY --from=windows /usr/src/plugins/bin/* /usr/src/plugins/windows/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p /usr/src/plugins/bin && \
     mkdir -p /usr/src/plugins/rhel9/bin && \
     mkdir -p /usr/src/plugins/windows/bin
 COPY --from=rhel9 /usr/src/plugins/bin/* /usr/src/plugins/bin/
-COPY --from=rhel9 /usr/src/plugins/bin/* /usr/src/plugins/rhel9/bin/
+RUN ln /usr/src/plugins/bin/* /usr/src/plugins/rhel9/bin/
 COPY --from=windows /usr/src/plugins/bin/* /usr/src/plugins/windows/bin/
 
 LABEL io.k8s.display-name="Container Networking Plugins" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,12 @@ WORKDIR /
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 RUN mkdir -p /usr/src/plugins/bin && \
     mkdir -p /usr/src/plugins/rhel9/bin && \
+    mkdir -p /usr/src/plugins/rhel10/bin && \
     mkdir -p /usr/src/plugins/windows/bin
 COPY --from=rhel9 /usr/src/plugins/bin/* /usr/src/plugins/bin/
 RUN ln /usr/src/plugins/bin/* /usr/src/plugins/rhel9/bin/
+# For now assume rhel9 binaries are compatible with rhel10
+RUN ln /usr/src/plugins/bin/* /usr/src/plugins/rhel10/bin/
 COPY --from=windows /usr/src/plugins/bin/* /usr/src/plugins/windows/bin/
 
 LABEL io.k8s.display-name="Container Networking Plugins" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,7 @@ RUN ./build_linux.sh && \
     cd /usr/src/plugins/bin
 WORKDIR /
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.21 AS rhel8
-ADD . /usr/src/plugins
-WORKDIR /usr/src/plugins
-ENV CGO_ENABLED=0
-RUN ./build_linux.sh && \
-    cd /usr/src/plugins/bin
-WORKDIR /
-
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.21 AS windows
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS windows
 ADD . /usr/src/plugins
 WORKDIR /usr/src/plugins
 ENV CGO_ENABLED=0
@@ -25,12 +17,9 @@ WORKDIR /
 
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 RUN mkdir -p /usr/src/plugins/bin && \
-    mkdir -p /usr/src/plugins/rhel8/bin && \
     mkdir -p /usr/src/plugins/rhel9/bin && \
     mkdir -p /usr/src/plugins/windows/bin
-COPY --from=rhel8 /usr/src/plugins/bin/* /usr/src/plugins/rhel8/bin/
-# pod container image is RHEL8 based, so use rhel8
-COPY --from=rhel8 /usr/src/plugins/bin/* /usr/src/plugins/bin/
+COPY --from=rhel9 /usr/src/plugins/bin/* /usr/src/plugins/bin/
 COPY --from=rhel9 /usr/src/plugins/bin/* /usr/src/plugins/rhel9/bin/
 COPY --from=windows /usr/src/plugins/bin/* /usr/src/plugins/windows/bin/
 

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -17,7 +17,7 @@ for d in $PLUGINS; do
 		plugin="$(basename "$d")"
 		if [ "${plugin}" != "windows" ]; then
 			echo "  $plugin"
-			${GO:-go} build -o "${PWD}/bin/$plugin" "$@" ./"$d"
+			${GO:-go} build -o "${PWD}/bin/$plugin" -ldflags "-s -w" "$@" ./"$d"
 		fi
 	fi
 done


### PR DESCRIPTION
Remove rhel8 and rhel9 specific builds. These are no longer necessary since https://github.com/openshift/cluster-network-operator/pull/2967