### PR TITLE
[release-4.12] OCPBUGS-85661: CI Build root image tag sync with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.10
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containernetworking/plugins
 
-go 1.20
+go 1.19
 
 require (
 	github.com/Microsoft/hcsshim v0.11.1


### PR DESCRIPTION
Aligning CI build root tags, Dockerfile base image and min go version in go.mod with ART