### PR TITLE
[release-4.15] OCPBUGS-85668: CI Build root image tag sync with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.10
+  tag: rhel-8-release-golang-1.20-openshift-4.15


### PR DESCRIPTION
Aligning CI build root tag with ART