### PR TITLE
[release-4.16] OCPBUGS-85669: CI Build root image tag sync with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.10
+  tag: rhel-9-release-golang-1.21-openshift-4.16


### PR DESCRIPTION
Align CI build root tag with ART