### PR TITLE
[release-4.19] OCPBUGS-85715: CI Build root image tag sync with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.10
+  tag: rhel-9-release-golang-1.23-openshift-4.19


### PR DESCRIPTION
Updated the CI Build Root image tag for the 4.19 branch to align with Golang builder version 1.23 from the ART 4.19 stream.

Impact: This alignment ensures uniformity between Prow CI testing and ART build/shipment processes by locking them to the same Golang version.